### PR TITLE
Force deepmerge-ts 8.0.0 for the prisma config chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,5 +103,8 @@
     "vite": "7.3.6",
     "vite-tsconfig-paths": "^4.2.3",
     "vitest": "4.1.2"
+  },
+  "resolutions": {
+    "deepmerge-ts": "8.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3758,10 +3758,10 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge-ts@7.1.5:
-  version "7.1.5"
-  resolved "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz#ff818564007f5c150808d2b7b732cac83aa415ab"
-  integrity sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==
+deepmerge-ts@7.1.5, deepmerge-ts@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.0.tgz#9fde9f1122d44ab4d1de31eda3e20b55693c8e59"
+  integrity sha512-ICNjaP0ML+eSdEpJYQC46XiAn/UjAdwbEl0dE8p85ZTeNDinN4Kd4+9jS4OSAuH7st6eC7rQhsqTF5zIDaUm2g==
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
## Why

Dependabot cannot fix the deepmerge-ts alert: the prisma config chain (via lightning-accounts) pins deepmerge-ts 7.1.5, and the non-vulnerable line starts at 8.0.0. The security update runs fail on master (scout findings 2026-08-27).

## What Changed

Added a yarn resolution forcing deepmerge-ts 8.0.0 and regenerated yarn.lock. This repo has no CI workflow, so lint/test/build were verified locally before merge.

## Verification

- yarn install clean; only deepmerge-ts entries changed.
- Local lint, unit tests, and production build pass.