### PR TITLE
Resolve brace-expansion to a non-vulnerable version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,9 +3281,9 @@ bolt09@2.2.0:
   integrity sha512-MzpiDQE4QavQTh5EqNv+Tmv+yoZMHys3j4OU3iiGO50IAu7FbVWmj1sipHIT+lvCKG6ROBFIJezND2vE3io75Q==
 
 brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
## Why

The brace-expansion security update keeps failing: the eslint toolchain pins the 1.x line and the lock was stuck on 1.1.16, below the non-vulnerable 1.1.18.

## What Changed

Re-resolved the stale yarn.lock selector to 1.1.18 (within the declared ^1.1.7 range, API-compatible).

## Verification

- yarn install clean; single lock entry changed.
- CI runs install, lint, tests, and build.